### PR TITLE
style: fix code overflow in smaller screens

### DIFF
--- a/packages/suspense-website/src/components/Code.module.css
+++ b/packages/suspense-website/src/components/Code.module.css
@@ -5,6 +5,7 @@
   white-space: pre;
   border-radius: 0.5rem;
   padding: 0.25rem 0.5rem;
+  overflow-x: auto;
 }
 
 .LineNumber {


### PR DESCRIPTION
Code block overflows in smaller screens

<img width="216" alt="image" src="https://user-images.githubusercontent.com/22864071/221071008-0c777229-2651-4d43-9301-6ed780eaa83f.png">
