### PR TITLE
Support aborting cache and streaming cache requests

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,8 +1,8 @@
-name: "Tests: E2E"
+name: "Jest unit tests"
 on: [pull_request]
 jobs:
   tests_e2e:
-    name: Run end-to-end tests
+    name: Run unit tests with Jest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -11,5 +11,5 @@ jobs:
         run: yarn
       - name: Build NPM package
         run: yarn prerelease
-      - name: Run Playwright tests
-        run: cd packages/suspense-website && yarn test:e2e
+      - name: Run tests
+        run: cd packages/suspense && yarn test

--- a/packages/suspense-website/root.css
+++ b/packages/suspense-website/root.css
@@ -92,6 +92,7 @@ h3,
 h4,
 h5 {
   margin: 0;
+  font-weight: normal;
 }
 
 p {

--- a/packages/suspense-website/src/components/ScrollToTop.tsx
+++ b/packages/suspense-website/src/components/ScrollToTop.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useLocation, useNavigationType } from "react-router-dom";
 
 export default function ScrollToTop(): null {
-  const location = useLocation();
+  const { hash } = useLocation();
   const navigationType = useNavigationType();
 
   useEffect(() => {
@@ -16,16 +16,16 @@ export default function ScrollToTop(): null {
     }
 
     // In all other cases, check fragment/scroll to top
-    let hash = location.hash;
     if (hash) {
       let element = document.querySelector(hash);
+      console.log("found element:", element);
       if (element) {
         element.scrollIntoView({ block: "start", behavior: "smooth" });
       }
     } else {
       window.scrollTo(0, 0);
     }
-  }, [location, navigationType]);
+  }, [hash, navigationType]);
 
   return null;
 }

--- a/packages/suspense-website/src/components/SubHeading.tsx
+++ b/packages/suspense-website/src/components/SubHeading.tsx
@@ -3,5 +3,11 @@ import { ReactNode } from "react";
 import styles from "./SubHeading.module.css";
 
 export default function SubHeading({ title }: { title: ReactNode }) {
-  return <div className={styles.SubHeading}>{title}</div>;
+  const id = title.toString().toLowerCase().replace(/\s/g, "-");
+
+  return (
+    <h2 className={styles.SubHeading} id={id}>
+      {title}
+    </h2>
+  );
 }

--- a/packages/suspense-website/src/examples/createCache/abort.ts
+++ b/packages/suspense-website/src/examples/createCache/abort.ts
@@ -1,0 +1,7 @@
+// TODO
+import { userProfileCache } from "./cache";
+
+const userId = "123";
+
+// REMOVE_BEFORE
+userProfileCache.abort(userId);

--- a/packages/suspense-website/src/examples/createCache/abort.ts
+++ b/packages/suspense-website/src/examples/createCache/abort.ts
@@ -1,4 +1,3 @@
-// TODO
 import { userProfileCache } from "./cache";
 
 const userId = "123";

--- a/packages/suspense-website/src/examples/createCache/cacheWithSignal.ts
+++ b/packages/suspense-website/src/examples/createCache/cacheWithSignal.ts
@@ -1,0 +1,15 @@
+import { CacheLoadOptions, createCache } from "suspense";
+
+export const userProfileCache = createCache<[userId: string], JSON>(
+  async (userId: string, options: CacheLoadOptions) => {
+    const { signal } = options;
+
+    // The native fetch API supports AbortSignals
+    // All that's required to support cancellation is to forward the signal
+    const response = await fetch(`https://example.com/user?id=${userId}`, {
+      signal,
+    });
+    const json = await response.json();
+    return json;
+  }
+);

--- a/packages/suspense-website/src/examples/createStreamingCache/abort.ts
+++ b/packages/suspense-website/src/examples/createStreamingCache/abort.ts
@@ -1,4 +1,3 @@
-// TODO
 import { userCommentsCache } from "./cache";
 
 const userId = "123";

--- a/packages/suspense-website/src/examples/createStreamingCache/abort.ts
+++ b/packages/suspense-website/src/examples/createStreamingCache/abort.ts
@@ -1,0 +1,7 @@
+// TODO
+import { userCommentsCache } from "./cache";
+
+const userId = "123";
+
+// REMOVE_BEFORE
+userCommentsCache.abort(userId);

--- a/packages/suspense-website/src/examples/createStreamingCache/cacheWithKey.ts
+++ b/packages/suspense-website/src/examples/createStreamingCache/cacheWithKey.ts
@@ -1,4 +1,4 @@
-import { createStreamingCache, StreamingProgressNotifier } from "suspense";
+import { createStreamingCache, StreamingCacheLoadOptions } from "suspense";
 
 class ApiClient {
   async fetchComments(
@@ -19,14 +19,14 @@ export const userCommentsCache = createStreamingCache<
 >(
   // In this example, comments are fetched using a "client" object
   async (
-    notifier: StreamingProgressNotifier<string>,
+    { resolve, update }: StreamingCacheLoadOptions<string>,
     client: ApiClient,
     id: string
   ) =>
     client.fetchComments(
       id,
-      (comments: Comment[]) => notifier.update(comments),
-      () => notifier.resolve()
+      (comments: Comment[]) => update(comments),
+      () => resolve()
     ),
 
   // The id parameter is sufficiently unique to be the key

--- a/packages/suspense-website/src/examples/createStreamingCache/cacheWithSignal.ts
+++ b/packages/suspense-website/src/examples/createStreamingCache/cacheWithSignal.ts
@@ -1,0 +1,20 @@
+type Comment = any;
+// REMOVE_BEFORE
+import { createStreamingCache, StreamingCacheLoadOptions } from "suspense";
+
+export const userCommentsCache = createStreamingCache<
+  [userId: string],
+  Comment
+>(
+  async (
+    { signal, ...rest }: StreamingCacheLoadOptions<Comment>,
+    userId: string
+  ) => {
+    signal.onabort = () => {
+      // Abort the in-progress request here.
+      // How to do this depends on how the data is loaded.
+    };
+
+    // ...
+  }
+);

--- a/packages/suspense-website/src/examples/index.ts
+++ b/packages/suspense-website/src/examples/index.ts
@@ -11,6 +11,9 @@ function processExample(text: string): string {
 }
 
 const createCache = {
+  abort: processExample(
+    readFileSync(join(__dirname, "createCache", "abort.ts"), "utf8")
+  ),
   async: processExample(
     readFileSync(join(__dirname, "createCache", "async.ts"), "utf8")
   ),
@@ -19,6 +22,9 @@ const createCache = {
   ),
   cacheWithKey: processExample(
     readFileSync(join(__dirname, "createCache", "cacheWithKey.ts"), "utf8")
+  ),
+  cacheWithSignal: processExample(
+    readFileSync(join(__dirname, "createCache", "cacheWithSignal.ts"), "utf8")
   ),
   evict: processExample(
     readFileSync(join(__dirname, "createCache", "evict.ts"), "utf8")
@@ -50,12 +56,21 @@ const createDeferred = {
 };
 
 const createStreamingCache = {
+  abort: processExample(
+    readFileSync(join(__dirname, "createStreamingCache", "abort.ts"), "utf8")
+  ),
   cache: processExample(
     readFileSync(join(__dirname, "createStreamingCache", "cache.ts"), "utf8")
   ),
   cacheWithKey: processExample(
     readFileSync(
       join(__dirname, "createStreamingCache", "cacheWithKey.ts"),
+      "utf8"
+    )
+  ),
+  cacheWithSignal: processExample(
+    readFileSync(
+      join(__dirname, "createStreamingCache", "cacheWithSignal.ts"),
       "utf8"
     )
   ),

--- a/packages/suspense-website/src/routes/api/createCache.tsx
+++ b/packages/suspense-website/src/routes/api/createCache.tsx
@@ -103,6 +103,24 @@ export default function CreateCacheRoute() {
         </p>
         <Code code={createCache.hook} />
       </Block>
+      <Block>
+        <SubHeading title="Aborting a request" />
+        <p>
+          In-progress requests can be cancelled using an{" "}
+          <code>
+            <ExternalLink to="https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal">
+              AbortSignal
+            </ExternalLink>
+          </code>{" "}
+          so long as the load function supports it.
+        </p>
+        <Code code={createCache.cacheWithSignal} />
+        <p>
+          Requests can be aborted anywhere that side effects are permitted (e.g.
+          event handlers, effect cleanup functions).
+        </p>
+        <Code code={createCache.abort} />
+      </Block>
     </Container>
   );
 }

--- a/packages/suspense-website/src/routes/api/createStreamingCache.tsx
+++ b/packages/suspense-website/src/routes/api/createStreamingCache.tsx
@@ -7,6 +7,7 @@ import SubHeading from "../../components/SubHeading";
 import { Link } from "react-router-dom";
 import { USE_STREAMING_CACHE } from "../config";
 import Note from "../../components/Note";
+import { ExternalLink } from "../../components/ExternalLink";
 
 export default function CreateStreamingCacheRoute() {
   return (
@@ -58,6 +59,24 @@ export default function CreateStreamingCacheRoute() {
           Evicting cache values does not currently schedule an update with
           React.
         </Note>
+      </Block>
+      <Block>
+        <SubHeading title="Aborting a request" />
+        <p>
+          In-progress requests can be cancelled using an{" "}
+          <code>
+            <ExternalLink to="https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal">
+              AbortSignal
+            </ExternalLink>
+          </code>{" "}
+          so long as the load function supports it.
+        </p>
+        <Code code={createStreamingCache.cacheWithSignal} />
+        <p>
+          Requests can be aborted anywhere that side effects are permitted (e.g.
+          event handlers, effect cleanup functions).
+        </p>
+        <Code code={createStreamingCache.abort} />
       </Block>
     </Container>
   );

--- a/packages/suspense/CHANGELOG.md
+++ b/packages/suspense/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.7
+* `createCache` and `createStreamingCache` add support for cancellation via [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
+
 ## 0.0.6
 * `createStreamingCache` catches errors and automatically rejects a pending streaming value.
 

--- a/packages/suspense/src/constants.ts
+++ b/packages/suspense/src/constants.ts
@@ -1,4 +1,5 @@
 export const STATUS_NOT_STARTED = "not-started";
 export const STATUS_PENDING = "pending";
+export const STATUS_ABORTED = "aborted";
 export const STATUS_REJECTED = "rejected";
 export const STATUS_RESOLVED = "resolved";

--- a/packages/suspense/src/hooks/useCacheStatus.ts
+++ b/packages/suspense/src/hooks/useCacheStatus.ts
@@ -6,7 +6,7 @@ export function useCacheStatus<Params extends Array<any>>(
   cache: Cache<Params, any>,
   ...params: Params
 ): Status {
-  return useSyncExternalStore<Status | undefined>(
+  return useSyncExternalStore<Status>(
     (callback) => cache.subscribeToStatus(callback, ...params),
     () => cache.getStatus(...params),
     () => cache.getStatus(...params)

--- a/packages/suspense/src/hooks/useStreamingValues.ts
+++ b/packages/suspense/src/hooks/useStreamingValues.ts
@@ -31,6 +31,7 @@ export function useStreamingValues<Value, AdditionalData = undefined>(
       value.complete !== streamingValues.complete ||
       value.data !== streamingValues.data ||
       value.progress !== streamingValues.progress ||
+      value.status !== streamingValues.status ||
       value.values !== streamingValues.values
     ) {
       ref.current = {
@@ -47,7 +48,9 @@ export function useStreamingValues<Value, AdditionalData = undefined>(
 
   const throttledSubscribe = useCallback(
     (callback: () => void) => {
-      const callbackWrapper = throttle(callback, throttleUpdatesBy);
+      const callbackWrapper = throttle(() => {
+        callback();
+      }, throttleUpdatesBy);
 
       return streamingValues.subscribe(callbackWrapper);
     },

--- a/packages/suspense/src/utils/assertPendingRecord.ts
+++ b/packages/suspense/src/utils/assertPendingRecord.ts
@@ -1,8 +1,11 @@
 import { STATUS_PENDING } from "../constants";
-import { Record } from "../types";
+import { PendingRecord, Record } from "../types";
 import { assert } from "./assert";
+import { isPendingRecord } from "./isPendingRecord";
 
-export function assertPendingRecord(record: Record<any>): boolean {
-  assert(record.status === STATUS_PENDING);
+export function assertPendingRecord(
+  record: Record<any>
+): record is PendingRecord<any> {
+  assert(isPendingRecord(record));
   return true;
 }

--- a/packages/suspense/src/utils/createDeferred.ts
+++ b/packages/suspense/src/utils/createDeferred.ts
@@ -8,7 +8,7 @@ let MAX_LOOP_COUNT = 1_000;
 //
 // A "deferred" is a "thenable" that has convenience resolve/reject methods.
 export function createDeferred<T>(debugLabel?: string): Deferred<T> {
-  const resolveCallbacks: Set<(value: T) => void> = new Set();
+  const resolveCallbacks: Set<(value?: T) => void> = new Set();
   const rejectCallbacks: Set<(error: Error) => void> = new Set();
 
   let status: "unresolved" | "resolved" | "rejected" = "unresolved";
@@ -30,7 +30,7 @@ export function createDeferred<T>(debugLabel?: string): Deferred<T> {
 
   const deferred: Deferred<T> = {
     then(
-      resolveCallback: (value: T) => void,
+      resolveCallback: (value?: T) => void,
       rejectCallback: (error: Error) => void
     ) {
       switch (status) {
@@ -73,7 +73,7 @@ export function createDeferred<T>(debugLabel?: string): Deferred<T> {
       rejectCallbacks.clear();
       resolveCallbacks.clear();
     },
-    resolve(value: T) {
+    resolve(value?: T) {
       if (status !== "unresolved") {
         throw Error(`Deferred has already been ${status}`);
       }

--- a/packages/suspense/src/utils/isPendingRecord.ts
+++ b/packages/suspense/src/utils/isPendingRecord.ts
@@ -1,0 +1,8 @@
+import { STATUS_PENDING } from "../constants";
+import { PendingRecord, Record } from "../types";
+
+export function isPendingRecord(
+  record: Record<any>
+): record is PendingRecord<any> {
+  return record.status === STATUS_PENDING;
+}

--- a/packages/suspense/src/utils/wrapAbortSignal.test.ts
+++ b/packages/suspense/src/utils/wrapAbortSignal.test.ts
@@ -1,0 +1,39 @@
+import { wrapAbortSignal } from "./wrapAbortSignal";
+
+describe("wrapAbortSignal", () => {
+  it("should abort", () => {
+    const abortController = new AbortController();
+    const wrapped = wrapAbortSignal(abortController.signal);
+    expect(wrapped.signal.aborted).toBe(false);
+    wrapped.abort();
+    expect(abortController.signal.aborted).toBe(false);
+    expect(wrapped.signal.aborted).toBe(true);
+  });
+
+  it("should abort when the wrapped signal is already aborted", () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    expect(abortController.signal.aborted).toBe(true);
+    const wrapped = wrapAbortSignal(abortController.signal);
+    expect(wrapped.signal.aborted).toBe(true);
+  });
+
+  it("should abort when the wrapped signal aborts", () => {
+    const abortController = new AbortController();
+    const wrapped = wrapAbortSignal(abortController.signal);
+    expect(wrapped.signal.aborted).toBe(false);
+    abortController.abort();
+    expect(abortController.signal.aborted).toBe(true);
+    expect(wrapped.signal.aborted).toBe(true);
+  });
+
+  it("should remove listener when unwrapped", () => {
+    const abortController = new AbortController();
+    const wrapped = wrapAbortSignal(abortController.signal);
+    expect(wrapped.signal.aborted).toBe(false);
+    wrapped.unwrap();
+    abortController.abort();
+    expect(abortController.signal.aborted).toBe(true);
+    expect(wrapped.signal.aborted).toBe(false);
+  });
+});

--- a/packages/suspense/src/utils/wrapAbortSignal.ts
+++ b/packages/suspense/src/utils/wrapAbortSignal.ts
@@ -1,0 +1,31 @@
+export function wrapAbortSignal(signal: AbortSignal): {
+  abort: () => void;
+  signal: AbortSignal;
+  unwrap: () => void;
+} {
+  const controller = new AbortController();
+
+  function onAbort() {
+    signal.removeEventListener("abort", onAbort);
+
+    controller.abort();
+  }
+
+  if (signal.aborted) {
+    controller.abort();
+  } else {
+    signal.addEventListener("abort", onAbort);
+  }
+
+  return {
+    abort: () => {
+      controller.abort();
+
+      signal.removeEventListener("abort", onAbort);
+    },
+    signal: controller.signal,
+    unwrap: () => {
+      signal.removeEventListener("abort", onAbort);
+    },
+  };
+}


### PR DESCRIPTION
Using [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), requests can be aborted anywhere that side effects are permitted (e.g. event handlers, effect cleanup functions).

Assuming the cache supports the signal, e.g.
```tsx
 import { CacheLoadOptions, createCache } from "suspense";
 
 export const userProfileCache = createCache<[userId: string], JSON>(
   async (userId: string, options: CacheLoadOptions) => {
     const { signal } = options;
 
     // The native fetch API supports AbortSignals
     // All that's required to support cancellation is to forward the signal
     const response = await fetch(`https://example.com/user?id=${userId}`, {
       signal,
     });
     const json = await response.json();
     return json;
   }
 );
```

Then all that's needed to abort the request is to notify the cache:
```tsx
userProfileCache.abort(userId);
```

Resolves #2.