### PR TITLE
Add WeakRef and FinalizationRegistry to createCache

### DIFF
--- a/.github/workflows/jest.browser.yml
+++ b/.github/workflows/jest.browser.yml
@@ -2,7 +2,7 @@ name: "Jest unit tests"
 on: [pull_request]
 jobs:
   tests_e2e:
-    name: Run unit tests with Jest
+    name: Run Jest (browser based) unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/jest.node.yml
+++ b/.github/workflows/jest.node.yml
@@ -1,0 +1,15 @@
+name: "Jest unit tests"
+on: [pull_request]
+jobs:
+  tests_e2e:
+    name: Run Jest (node based) unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Initialize Yarn and install package dependencies
+        run: yarn
+      - name: Build NPM package
+        run: yarn prerelease
+      - name: Run tests
+        run: cd packages/suspense && yarn test:node

--- a/packages/suspense-website/index.tsx
+++ b/packages/suspense-website/index.tsx
@@ -6,10 +6,11 @@ import {
   CREATE_DEFERRED,
   CREATE_SINGLE_ENTRY_CACHE,
   CREATE_STREAMING_CACHE,
-  EXAMPLE_ABORT_A_REQUEST,
-  EXAMPLE_FETCH_WITH_STATUS,
-  EXAMPLE_MUTATING_A_CACHE_VALUE,
-  EXAMPLE_STREAMING_CACHE,
+  GUIDE_ABORT_A_REQUEST,
+  GUIDE_FETCH_WITH_STATUS,
+  GUIDE_MEMORY_MANAGEMENT,
+  GUIDE_MUTATING_A_CACHE_VALUE,
+  GUIDE_STREAMING_CACHE,
   IS_THENNABLE,
   USE_CACHE_STATUS,
   USE_STREAMING_CACHE,
@@ -25,6 +26,7 @@ import PageNotFoundRoute from "./src/routes/PageNotFound";
 import UseCacheStatusRoute from "./src/routes/api/useCacheStatus";
 import UseStreamingValuesRoute from "./src/routes/api/useStreamingValues";
 import AbortingRequestRoute from "./src/routes/examples/aborting-a-request";
+import MemoryManagementRoute from "./src/routes/examples/memory-management";
 import MutatingCacheValueRoute from "./src/routes/examples/mutating-a-cache-value";
 import RenderingStatusWhileFetchingRoute from "./src/routes/examples/rendering-status-while-fetching";
 import CreatingStreamingCacheRoute from "./src/routes/examples/streaming-cache";
@@ -51,19 +53,23 @@ root.render(
           element={<CreateStreamingCacheRoute />}
         />
         <Route
-          path={EXAMPLE_ABORT_A_REQUEST}
+          path={GUIDE_ABORT_A_REQUEST}
           element={<AbortingRequestRoute />}
         />
         <Route
-          path={EXAMPLE_FETCH_WITH_STATUS}
+          path={GUIDE_FETCH_WITH_STATUS}
           element={<RenderingStatusWhileFetchingRoute />}
         />
         <Route
-          path={EXAMPLE_MUTATING_A_CACHE_VALUE}
+          path={GUIDE_MEMORY_MANAGEMENT}
+          element={<MemoryManagementRoute />}
+        />
+        <Route
+          path={GUIDE_MUTATING_A_CACHE_VALUE}
           element={<MutatingCacheValueRoute />}
         />
         <Route
-          path={EXAMPLE_STREAMING_CACHE}
+          path={GUIDE_STREAMING_CACHE}
           element={<CreatingStreamingCacheRoute />}
         />
         <Route path={IS_THENNABLE} element={<IsThenableRoute />} />

--- a/packages/suspense-website/src/components/Note.module.css
+++ b/packages/suspense-website/src/components/Note.module.css
@@ -55,6 +55,17 @@
   flex: 0 0 1.75rem !important;
 }
 
+.Content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.Content * {
+  line-height: 1;
+  margin: 0;
+}
+
 .Note[data-type="note"] .Content,
 .Note[data-type="quote"] .Content {
   line-height: 1rem;

--- a/packages/suspense-website/src/examples/createCache/cacheWithoutWeakRef.ts
+++ b/packages/suspense-website/src/examples/createCache/cacheWithoutWeakRef.ts
@@ -1,0 +1,11 @@
+import { CacheLoadOptions, createCache } from "suspense";
+
+const load = async () => null as any;
+
+// REMOVE_BEFORE
+
+createCache<[userId: string], JSON>({
+  config: { useWeakRef: false },
+  load,
+  // ...
+});

--- a/packages/suspense-website/src/examples/index.ts
+++ b/packages/suspense-website/src/examples/index.ts
@@ -31,6 +31,12 @@ const createCache = {
   cacheWithSignal: processExample(
     readFileSync(join(__dirname, "createCache", "cacheWithSignal.ts"), "utf8")
   ),
+  cacheWithoutWeakRef: processExample(
+    readFileSync(
+      join(__dirname, "createCache", "cacheWithoutWeakRef.ts"),
+      "utf8"
+    )
+  ),
   evict: processExample(
     readFileSync(join(__dirname, "createCache", "evict.ts"), "utf8")
   ),

--- a/packages/suspense-website/src/routes/Home.tsx
+++ b/packages/suspense-website/src/routes/Home.tsx
@@ -10,9 +10,10 @@ import {
   CREATE_DEFERRED,
   CREATE_SINGLE_ENTRY_CACHE,
   CREATE_STREAMING_CACHE,
-  EXAMPLE_ABORT_A_REQUEST,
-  EXAMPLE_FETCH_WITH_STATUS,
-  EXAMPLE_STREAMING_CACHE,
+  GUIDE_ABORT_A_REQUEST,
+  GUIDE_FETCH_WITH_STATUS,
+  GUIDE_MEMORY_MANAGEMENT,
+  GUIDE_STREAMING_CACHE,
   IS_THENNABLE,
   USE_CACHE_STATUS,
   USE_STREAMING_CACHE,
@@ -94,18 +95,23 @@ export default function Route() {
         <SubHeading title="Guides" />
         <ul>
           <LinkListItem
+            children="Memory management"
+            to={GUIDE_MEMORY_MANAGEMENT}
+            type="plaintext"
+          />
+          <LinkListItem
             children="Aborting a request"
-            to={EXAMPLE_ABORT_A_REQUEST}
+            to={GUIDE_ABORT_A_REQUEST}
             type="plaintext"
           />
           <LinkListItem
             children="Creating a streaming cache"
-            to={EXAMPLE_STREAMING_CACHE}
+            to={GUIDE_STREAMING_CACHE}
             type="plaintext"
           />
           <LinkListItem
             children="Rendering cache status"
-            to={EXAMPLE_FETCH_WITH_STATUS}
+            to={GUIDE_FETCH_WITH_STATUS}
             type="plaintext"
           />
         </ul>

--- a/packages/suspense-website/src/routes/api/createCache.tsx
+++ b/packages/suspense-website/src/routes/api/createCache.tsx
@@ -5,7 +5,11 @@ import { createCache } from "../../examples";
 import Header from "../../components/Header";
 import SubHeading from "../../components/SubHeading";
 import { Link } from "react-router-dom";
-import { IS_THENNABLE, USE_CACHE_STATUS } from "../config";
+import {
+  GUIDE_MEMORY_MANAGEMENT,
+  IS_THENNABLE,
+  USE_CACHE_STATUS,
+} from "../config";
 import Note from "../../components/Note";
 import { ExternalLink } from "../../components/ExternalLink";
 
@@ -48,6 +52,11 @@ export default function Route() {
           that's provided to support cancellation.
         </p>
         <Code code={createCache.cacheWithSignal} />
+        <Note>
+          Caches use <code>WeakRef</code> and <code>FinalizationRegistry</code>{" "}
+          by default,{" "}
+          <Link to={GUIDE_MEMORY_MANAGEMENT}>but this is configurable</Link>.
+        </Note>
       </Block>
       <Block>
         <SubHeading title="Using a cache with suspense" />

--- a/packages/suspense-website/src/routes/config.ts
+++ b/packages/suspense-website/src/routes/config.ts
@@ -1,3 +1,4 @@
+// API
 export const CREATE_CACHE = "/createCache";
 export const CREATE_DEFERRED = "/createDeferred";
 export const CREATE_SINGLE_ENTRY_CACHE = "/createSingleEntryCache";
@@ -6,8 +7,9 @@ export const IS_THENNABLE = "/isThenable";
 export const USE_CACHE_STATUS = "/useCacheStatus";
 export const USE_STREAMING_CACHE = "/useStreamingValues";
 
-// Examples
-export const EXAMPLE_ABORT_A_REQUEST = "/example/abort-a-request";
-export const EXAMPLE_FETCH_WITH_STATUS = "/example/rendering-cache-status";
-export const EXAMPLE_MUTATING_A_CACHE_VALUE = "/example/mutating-a-cache-value";
-export const EXAMPLE_STREAMING_CACHE = "/example/writing-a-streaming-cache";
+// Guides
+export const GUIDE_ABORT_A_REQUEST = "/guide/abort-a-request";
+export const GUIDE_FETCH_WITH_STATUS = "/guide/rendering-cache-status";
+export const GUIDE_MEMORY_MANAGEMENT = "/guide/memory-management";
+export const GUIDE_MUTATING_A_CACHE_VALUE = "/guide/mutating-a-cache-value";
+export const GUIDE_STREAMING_CACHE = "/guide/writing-a-streaming-cache";

--- a/packages/suspense-website/src/routes/examples/memory-management.tsx
+++ b/packages/suspense-website/src/routes/examples/memory-management.tsx
@@ -1,0 +1,49 @@
+import { Link } from "react-router-dom";
+import Block from "../../components/Block";
+import Code from "../../components/Code";
+import Container from "../../components/Container";
+import { ExternalLink } from "../../components/ExternalLink";
+import Header from "../../components/Header";
+import Note from "../../components/Note";
+import { createCache } from "../../examples";
+import { CREATE_CACHE } from "../config";
+
+export default function Route() {
+  return (
+    <Container>
+      <Block>
+        <Header title="memory management" />
+      </Block>
+      <Block>
+        <p>
+          Caches created with{" "}
+          <code>
+            <Link to={CREATE_CACHE}>createCache</Link>
+          </code>{" "}
+          use{" "}
+          <code>
+            <ExternalLink to="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef">
+              WeakRef
+            </ExternalLink>
+          </code>{" "}
+          and{" "}
+          <code>
+            <ExternalLink to="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry">
+              FinalizationRegistry
+            </ExternalLink>
+          </code>{" "}
+          APIs to avoid leaking memory. This behavior can be disabled using the{" "}
+          <code>useWeakRef</code> configuration flag.
+        </p>
+        <Code code={createCache.cacheWithoutWeakRef} />
+        <Note type="warn">
+          <p>Caches that don't use weak refs may leak memory over time.</p>
+          <p>
+            To avoid this, use the <code>evict</code> method to remove entries
+            once you are done using them.
+          </p>
+        </Note>
+      </Block>
+    </Container>
+  );
+}

--- a/packages/suspense-website/src/routes/examples/streaming-cache.tsx
+++ b/packages/suspense-website/src/routes/examples/streaming-cache.tsx
@@ -22,7 +22,6 @@ export default function Route() {
           to render a larger data set as it incrementally loads.
         </p>
         <p>Click the "start demo" button to fetch user data in the cache.</p>
-        {/*<Code code={demos.} />*/}
       </Block>
       <Block type="demo">
         <Demo />

--- a/packages/suspense/jest.config.node.js
+++ b/packages/suspense/jest.config.node.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.test.node.{ts,tsx}"],
+};

--- a/packages/suspense/package.json
+++ b/packages/suspense/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "build": "parcel build",
     "test": "jest",
+    "test:node": "node --expose-gc node_modules/.bin/jest --config=jest.config.node.js",
+    "test:node:watch": "node --expose-gc node_modules/.bin/jest --config=jest.config.node.js --watch",
     "test:watch": "jest --watch",
     "watch": "parcel watch"
   },

--- a/packages/suspense/src/cache/createCache.test.node.ts
+++ b/packages/suspense/src/cache/createCache.test.node.ts
@@ -1,0 +1,80 @@
+import { createCache } from "./createCache";
+import { Cache, CacheLoadOptions } from "../types";
+import { WeakRefMap } from "../utils/WeakRefMap";
+import { requestGC, waitForGC } from "../utils/test";
+
+describe("createCache", () => {
+  let cache: Cache<[string], Object>;
+  let fetch: jest.Mock<Promise<Object> | Object, [string, CacheLoadOptions]>;
+
+  afterEach(async () => {
+    await runAndWaitForGC();
+  });
+
+  beforeEach(() => {
+    fetch = jest.fn();
+    fetch.mockImplementation((key: string) => {
+      if (key.startsWith("async")) {
+        return Promise.resolve(key);
+      } else if (key.startsWith("error")) {
+        return Promise.reject(key);
+      } else {
+        return key;
+      }
+    });
+  });
+
+  it("should use WeakRefs if requested", async () => {
+    cache = createCache<[string], Object>({
+      config: { useWeakRef: true },
+      load: fetch,
+    });
+
+    cache.cache(createObject(), "one");
+    cache.cache(createObject(), "two");
+    cache.cache(createObject(), "three");
+
+    expect(cache.getValueIfCached("one")).not.toBeUndefined();
+    expect(cache.getValueIfCached("two")).not.toBeUndefined();
+    expect(cache.getValueIfCached("three")).not.toBeUndefined();
+
+    await runAndWaitForGC();
+
+    expect(cache.getValueIfCached("one")).toBeUndefined();
+    expect(cache.getValueIfCached("two")).toBeUndefined();
+    expect(cache.getValueIfCached("three")).toBeUndefined();
+  });
+
+  it("should not use WeakRefs if requested", async () => {
+    cache = createCache<[string], Object>({
+      config: { useWeakRef: false },
+      load: fetch,
+    });
+
+    cache.cache(createObject(), "one");
+    cache.cache(createObject(), "two");
+
+    expect(cache.getValueIfCached("one")).not.toBeUndefined();
+    expect(cache.getValueIfCached("two")).not.toBeUndefined();
+
+    await runAndWaitForGC();
+
+    expect(cache.getValueIfCached("one")).not.toBeUndefined();
+    expect(cache.getValueIfCached("two")).not.toBeUndefined();
+  });
+});
+
+function createObject(): Object {
+  return {};
+}
+
+async function runAndWaitForGC() {
+  const finalizer = jest.fn();
+
+  const map = new WeakRefMap(finalizer);
+  map.set("control", createObject());
+
+  requestGC();
+
+  await waitForGC(() => finalizer.mock.calls.length > 0);
+}

--- a/packages/suspense/src/cache/createCache.test.node.ts
+++ b/packages/suspense/src/cache/createCache.test.node.ts
@@ -1,15 +1,10 @@
 import { createCache } from "./createCache";
 import { Cache, CacheLoadOptions } from "../types";
-import { WeakRefMap } from "../utils/WeakRefMap";
 import { requestGC, waitForGC } from "../utils/test";
 
 describe("createCache", () => {
   let cache: Cache<[string], Object>;
   let fetch: jest.Mock<Promise<Object> | Object, [string, CacheLoadOptions]>;
-
-  afterEach(async () => {
-    await runAndWaitForGC();
-  });
 
   beforeEach(() => {
     fetch = jest.fn();
@@ -38,7 +33,8 @@ describe("createCache", () => {
     expect(cache.getValueIfCached("two")).not.toBeUndefined();
     expect(cache.getValueIfCached("three")).not.toBeUndefined();
 
-    await runAndWaitForGC();
+    await requestGC();
+    await waitForGC();
 
     expect(cache.getValueIfCached("one")).toBeUndefined();
     expect(cache.getValueIfCached("two")).toBeUndefined();
@@ -57,7 +53,8 @@ describe("createCache", () => {
     expect(cache.getValueIfCached("one")).not.toBeUndefined();
     expect(cache.getValueIfCached("two")).not.toBeUndefined();
 
-    await runAndWaitForGC();
+    await requestGC();
+    await waitForGC();
 
     expect(cache.getValueIfCached("one")).not.toBeUndefined();
     expect(cache.getValueIfCached("two")).not.toBeUndefined();
@@ -66,15 +63,4 @@ describe("createCache", () => {
 
 function createObject(): Object {
   return {};
-}
-
-async function runAndWaitForGC() {
-  const finalizer = jest.fn();
-
-  const map = new WeakRefMap(finalizer);
-  map.set("control", createObject());
-
-  requestGC();
-
-  await waitForGC(() => finalizer.mock.calls.length > 0);
 }

--- a/packages/suspense/src/cache/createCache.ts
+++ b/packages/suspense/src/cache/createCache.ts
@@ -17,16 +17,27 @@ import {
 import { assertPendingRecord } from "../utils/assertPendingRecord";
 import { isThenable } from "../utils/isThenable";
 import { isPendingRecord } from "../utils/isPendingRecord";
+import { WeakRefMap } from "../utils/WeakRefMap";
+
+export type CreateCacheOptions<Params extends Array<any>, Value> = {
+  config?: {
+    useWeakRef?: boolean;
+  };
+  debugLabel?: string;
+  getKey?: (...params: Params) => string;
+  load: (...params: [...Params, CacheLoadOptions]) => Thenable<Value> | Value;
+};
 
 // Enable to help with debugging in dev
 const DEBUG_LOG_IN_DEV = false;
 
-export function createCache<Params extends Array<any>, Value>(options: {
-  load: (...params: [...Params, CacheLoadOptions]) => Thenable<Value> | Value;
-  getKey?: (...params: Params) => string;
-  debugLabel?: string;
-}): Cache<Params, Value> {
-  const { debugLabel, getKey = defaultGetKey, load } = options;
+const WearRefMapSymbol = Symbol.for("WearRefMap");
+
+export function createCache<Params extends Array<any>, Value>(
+  options: CreateCacheOptions<Params, Value>
+): Cache<Params, Value> {
+  const { config = {}, debugLabel, getKey = defaultGetKey, load } = options;
+  const { useWeakRef = true } = config;
 
   const debugLogInDev = (debug: string, params?: Params, ...args: any[]) => {
     if (DEBUG_LOG_IN_DEV && process.env.NODE_ENV === "development") {
@@ -47,6 +58,10 @@ export function createCache<Params extends Array<any>, Value>(options: {
 
   const recordMap = new Map<string, Record<Value>>();
   const subscriberMap = new Map<string, Set<StatusCallback>>();
+  const weakRefMap = new WeakRefMap<string, Value>((cacheKey: string) => {
+    recordMap.delete(cacheKey);
+    subscriberMap.delete(cacheKey);
+  });
 
   function abort(...params: Params): boolean {
     const cacheKey = getKey(...params);
@@ -55,6 +70,7 @@ export function createCache<Params extends Array<any>, Value>(options: {
       debugLogInDev("abort()", params);
 
       recordMap.delete(cacheKey);
+      weakRefMap.delete(cacheKey);
 
       record.value.abortController.abort();
 
@@ -70,8 +86,10 @@ export function createCache<Params extends Array<any>, Value>(options: {
     const cacheKey = getKey(...params);
     const record: Record<Value> = {
       status: STATUS_RESOLVED,
-      value,
+      value: null,
     };
+
+    writeRecordValue(record, value, ...params);
 
     debugLogInDev("cache()", params, value);
 
@@ -82,6 +100,8 @@ export function createCache<Params extends Array<any>, Value>(options: {
     const cacheKey = getKey(...params);
 
     debugLogInDev(`evict()`, params);
+
+    weakRefMap.delete(cacheKey);
 
     return recordMap.delete(cacheKey);
   }
@@ -140,7 +160,7 @@ export function createCache<Params extends Array<any>, Value>(options: {
     } else if (record.status !== STATUS_RESOLVED) {
       throw Error(`Record found with status "${record.status}"`);
     } else {
-      return record.value;
+      return readRecordValue(record, ...params);
     }
   }
 
@@ -149,7 +169,7 @@ export function createCache<Params extends Array<any>, Value>(options: {
     const record = recordMap.get(cacheKey);
 
     if (record?.status === STATUS_RESOLVED) {
-      return record.value;
+      return readRecordValue(record, ...params);
     }
   }
 
@@ -165,7 +185,7 @@ export function createCache<Params extends Array<any>, Value>(options: {
       case STATUS_PENDING:
         return record.value.deferred;
       case STATUS_RESOLVED:
-        return record.value;
+        return readRecordValue(record, ...params);
       case STATUS_REJECTED:
         throw record.value;
     }
@@ -174,7 +194,7 @@ export function createCache<Params extends Array<any>, Value>(options: {
   function fetchSuspense(...params: Params): Value {
     const record = getOrCreateRecord(...params);
     if (record.status === STATUS_RESOLVED) {
-      return record.value;
+      return readRecordValue(record, ...params);
     } else if (isPendingRecord(record)) {
       throw record.value.deferred;
     } else {
@@ -210,7 +230,8 @@ export function createCache<Params extends Array<any>, Value>(options: {
 
       if (!abortSignal.aborted) {
         record.status = STATUS_RESOLVED;
-        record.value = value;
+
+        writeRecordValue(record, value, ...params);
 
         deferred.resolve(value);
       }
@@ -225,6 +246,16 @@ export function createCache<Params extends Array<any>, Value>(options: {
       if (!abortSignal.aborted) {
         notifySubscribers(...(params as unknown as Params));
       }
+    }
+  }
+
+  function readRecordValue(record: Record<Value>, ...params: Params): Value {
+    const value = record.value;
+    if (value === WearRefMapSymbol) {
+      const cacheKey = getKey(...params);
+      return weakRefMap.get(cacheKey);
+    } else {
+      return value;
     }
   }
 
@@ -252,6 +283,21 @@ export function createCache<Params extends Array<any>, Value>(options: {
           subscriberMap.delete(cacheKey);
         }
       };
+    }
+  }
+
+  function writeRecordValue(
+    record: Record<Value>,
+    value: Value,
+    ...params: Params
+  ): void {
+    if (useWeakRef && value != null && typeof value === "object") {
+      record.value = WearRefMapSymbol;
+
+      const cacheKey = getKey(...params);
+      weakRefMap.set(cacheKey, value);
+    } else {
+      record.value = value;
     }
   }
 

--- a/packages/suspense/src/cache/createSingleEntryCache.ts
+++ b/packages/suspense/src/cache/createSingleEntryCache.ts
@@ -1,20 +1,16 @@
-import { createCache } from "./createCache";
-import { Cache, CacheLoadOptions, Thenable } from "../types";
+import { createCache, CreateCacheOptions } from "./createCache";
+import { Cache } from "../types";
 
 const key = Symbol.for("createSingleEntryCache").toString();
 
-export function createSingleEntryCache<
-  Params extends Array<any>,
-  Value
->(options: {
-  load: (...params: [...Params, CacheLoadOptions]) => Thenable<Value> | Value;
-  debugLabel?: string;
-}): Cache<Params, Value> {
+export function createSingleEntryCache<Params extends Array<any>, Value>(
+  options: Omit<CreateCacheOptions<Params, Value>, "getKey">
+): Cache<Params, Value> {
   if (options.hasOwnProperty("getKey")) {
     throw Error("createSingleEntryCache does not support a getKey option");
   }
 
-  return createCache({
+  return createCache<Params, Value>({
     getKey: () => key,
     ...options,
   });

--- a/packages/suspense/src/utils/WeakRefMap.test.ts
+++ b/packages/suspense/src/utils/WeakRefMap.test.ts
@@ -1,0 +1,39 @@
+import { WeakRefMap } from "./WeakRefMap";
+
+describe("WeakRefMap", () => {
+  it("should implement a basic Map-like API", () => {
+    const finalizer = jest.fn();
+
+    const foo = { foo: true };
+    const bar = { bar: true };
+
+    const map = new WeakRefMap(finalizer);
+    map.set("foo", foo);
+    map.set("bar", bar);
+
+    expect(map.size()).toBe(2);
+    expect(map.has("foo")).toBe(true);
+    expect(map.has("bar")).toBe(true);
+    expect(map.get("foo")).toBe(foo);
+    expect(map.get("bar")).toBe(bar);
+
+    expect(map.delete("foo")).toBe(true);
+    expect(map.size()).toBe(1);
+    expect(map.has("foo")).toBe(false);
+    expect(map.get("foo")).toBe(undefined);
+    expect(map.has("bar")).toBe(true);
+    expect(map.get("bar")).toBe(bar);
+
+    map.set("bar", foo);
+    expect(map.size()).toBe(1);
+    expect(map.has("bar")).toBe(true);
+    expect(map.get("bar")).toBe(foo);
+
+    map.delete("bar");
+    expect(map.size()).toBe(0);
+    expect(map.has("foo")).toBe(false);
+    expect(map.has("bar")).toBe(false);
+    expect(map.get("foo")).toBe(undefined);
+    expect(map.get("bar")).toBe(undefined);
+  });
+});

--- a/packages/suspense/src/utils/WeakRefMap.ts
+++ b/packages/suspense/src/utils/WeakRefMap.ts
@@ -1,0 +1,52 @@
+export type FinalizerCallback<Key> = (key: Key) => void;
+
+export class WeakRefMap<Key, Value extends Object> {
+  private finalizationRegistry: FinalizationRegistry<Key>;
+  private map: Map<Key, WeakRef<Value>>;
+
+  constructor(finalizerCallback: FinalizerCallback<Key>) {
+    this.finalizationRegistry = new FinalizationRegistry<Key>((key) => {
+      this.map.delete(key);
+
+      finalizerCallback(key);
+    });
+    this.map = new Map<Key, WeakRef<Value>>();
+  }
+
+  delete(key: Key): boolean {
+    const weakRef = this.map.get(key);
+
+    const result = this.map.delete(key);
+
+    if (weakRef) {
+      const value = weakRef.deref();
+      if (value != null) {
+        this.finalizationRegistry.unregister(value);
+      }
+    }
+
+    return result;
+  }
+
+  get(key: Key): Value | undefined {
+    const weakRef = this.map.get(key);
+
+    return weakRef ? weakRef.deref() : undefined;
+  }
+
+  has(key: Key): boolean {
+    return this.map.has(key);
+  }
+
+  size(): number {
+    return this.map.size;
+  }
+
+  set(key: Key, value: Value): void {
+    this.map.set(key, new WeakRef(value));
+
+    if (value != null) {
+      this.finalizationRegistry.register(value, key, value);
+    }
+  }
+}

--- a/packages/suspense/src/utils/stringify.ts
+++ b/packages/suspense/src/utils/stringify.ts
@@ -1,0 +1,20 @@
+// Convenience function to JSON-stringify values that may contain circular references.
+export function stringify(value: any, space?: string | number): string {
+  const cache: any[] = [];
+
+  return JSON.stringify(
+    value,
+    (key, value) => {
+      if (typeof value === "object" && value !== null) {
+        if (cache.includes(value)) {
+          return "[Circular]";
+        }
+
+        cache.push(value);
+      }
+
+      return value;
+    },
+    space
+  );
+}

--- a/packages/suspense/src/utils/test.ts
+++ b/packages/suspense/src/utils/test.ts
@@ -1,22 +1,50 @@
-export function requestGC(): void {
+export async function requestGC() {
+  await wait(100);
+
   // Node --expose-gc flag
   global.gc();
+
+  await wait(100);
 }
 
 export async function wait(delay: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, delay));
 }
 
-export async function waitForGC(
-  condition: () => boolean,
-  timeoutInSeconds: number = 5
-): Promise<void> {
-  const startTime = process.hrtime();
+export async function waitUntil(
+  conditional: () => boolean,
+  timeout: number = 5000
+) {
+  let startTime = performance.now();
   do {
-    global.gc();
-    await wait(0);
-  } while (
-    condition() === false &&
-    process.hrtime(startTime)[0] < timeoutInSeconds
-  );
+    if (conditional()) {
+      return;
+    }
+
+    await wait(100);
+  } while (startTime + timeout > performance.now());
+
+  const elapsed = performance.now() - startTime;
+
+  throw Error(`Condition not met within ${elapsed}ms`);
+}
+
+export async function waitForGC(
+  conditional: () => boolean = () => true,
+  timeout: number = 5000
+): Promise<void> {
+  const finalizer = jest.fn();
+  const finalizationRegistry = new FinalizationRegistry(finalizer);
+  finalizationRegistry.register({}, "control");
+
+  await requestGC();
+
+  // Ensure some GC has occurred
+  await waitUntil(() => finalizer.mock.calls.length > 0);
+
+  expect(finalizer).toHaveBeenCalledTimes(1);
+  expect(finalizer).toHaveBeenCalledWith("control");
+
+  // Ensure additional constraints are met
+  await waitUntil(conditional, timeout);
 }

--- a/packages/suspense/src/utils/test.ts
+++ b/packages/suspense/src/utils/test.ts
@@ -1,0 +1,22 @@
+export function requestGC(): void {
+  // Node --expose-gc flag
+  global.gc();
+}
+
+export async function wait(delay: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+export async function waitForGC(
+  condition: () => boolean,
+  timeoutInSeconds: number = 5
+): Promise<void> {
+  const startTime = process.hrtime();
+  do {
+    global.gc();
+    await wait(0);
+  } while (
+    condition() === false &&
+    process.hrtime(startTime)[0] < timeoutInSeconds
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["ES2015", "DOM"],
+    "lib": ["DOM", "ES2015", "ES2021.WeakRef"],
     "module": "es2020",
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION
Use `WeakRef` and `FinalizationRegistry` to avoid "leaking" values that are only referenced in the cache.

A few thoughts:
- I've set this on by default, but provided an option to opt-out because some users (Replay) won't want it.
- `WeakRef` only works with objects, so e.g. large string values may still "leak" unless explicitly evicted.
- I don't know if this makes sense to add to the streaming cache; maybe we just require explicit eviction there.
- I'm not sure how this impacts runtime performance of the cache.
- Browser support is [pretty good](https://caniuse.com/?search=weakref).

---
- [x] Add `WeakRef` support
- [x] Add unit tests
- [x] Update documentation ([see here](https://suspense-git-issues-9-bvaughn.vercel.app/guide/memory-management))

(Issue #9)