### PR TITLE
Update cache hook arg types and add a `skip` option

### DIFF
--- a/packages/suspense/src/hooks/useImperativeCacheValue.ts
+++ b/packages/suspense/src/hooks/useImperativeCacheValue.ts
@@ -13,21 +13,29 @@ import {
 } from "../types";
 import { useCacheStatus } from "./useCacheStatus";
 
+export type UICVOptions = {
+  skip?: boolean;
+};
+
 export function useImperativeCacheValue<Params extends any[], Value>(
   cache: Cache<Params, Value>,
-  ...params: Params
+  params: Params,
+  options: UICVOptions = {}
 ):
   | ImperativeErrorResponse
   | ImperativePendingResponse
   | ImperativeResolvedResponse<Value> {
+  const { skip = false } = options;
   const status = useCacheStatus(cache, ...params);
 
   useEffect(() => {
     switch (status) {
       case STATUS_NOT_FOUND:
-        cache.prefetch(...params);
+        if (!skip) {
+          cache.prefetch(...params);
+        }
     }
-  }, [cache, status, ...params]);
+  }, [cache, status, skip, ...params]);
 
   switch (status) {
     case STATUS_REJECTED:


### PR DESCRIPTION
This PR:

- Updates `useImperativeCacheValue` so that the `Params` data is read as a single array arg instead of a rest spread, to simplify typing
- Adds a `{skip?: boolean}` option, which skips making the fetch request if true