### PR TITLE
Notify subscribers when an externally cached object replaces a pending record

### DIFF
--- a/packages/suspense/src/cache/createCache.test.ts
+++ b/packages/suspense/src/cache/createCache.test.ts
@@ -588,6 +588,30 @@ describe("createCache", () => {
       });
       expect(callbackA.mock.lastCall[0].value).toEqual(value);
     });
+
+    it("should notify subscribers when an externally cached object replaces a pending record", () => {
+      const cache = createCache<[string], Object>({
+        debugLabel: "cache",
+        load: async () => new Promise(() => {}),
+      });
+
+      cache.readAsync("externally-managed");
+
+      cache.subscribe(callbackA, "externally-managed");
+
+      expect(callbackA).toHaveBeenCalledWith({ status: STATUS_PENDING });
+
+      const value = { id: 123 };
+
+      cache.cache(value, "externally-managed");
+
+      expect(callbackA).toHaveBeenCalledTimes(2);
+      expect(callbackA).toHaveBeenCalledWith({
+        status: STATUS_RESOLVED,
+        value,
+      });
+      expect(callbackA.mock.lastCall[0].value).toEqual(value);
+    });
   });
 
   describe("getCache: LRU Cache", () => {

--- a/packages/suspense/src/cache/createCache.ts
+++ b/packages/suspense/src/cache/createCache.ts
@@ -196,6 +196,8 @@ export function createCache<Params extends Array<any>, Value>(
         // Don't leave any pending request hanging
         deferred.resolve(value);
 
+        notifySubscribers(params);
+
         return;
       }
     }


### PR DESCRIPTION
Before: https://app.replay.io/recording/pause-info-button-not-updated--7df917a8-97ed-40b4-8ead-1d19b92ebd3f - notice how the badge of the toolbar button for the Pause information panel isn't updated
After: https://app.replay.io/recording/pause-info-button-is-updated--5607e038-d9b8-4fbc-96cb-cbde92292be2
Fixes #41.