### PR TITLE
Allow React 19 as peer dependency in addition to 18

### DIFF
--- a/packages/suspense/package.json
+++ b/packages/suspense/package.json
@@ -67,8 +67,8 @@
     "point-utilities": "^0.0.2"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "browserslist": [
     "Chrome 79"


### PR DESCRIPTION
Now that 19 is GA, this should be allowed and seems to just work.
